### PR TITLE
Add Python and C++ implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,25 @@
-# KalmanSharp
 
-This repository contains a simple implementation of a Kalman filter in C#, using the MathNet.Numerics library.
+# Multi-Language Kalman Filter Implementations
 
-## Dependencies
+This repository contains implementations of a Kalman filter in multiple programming languages. Currently, the following languages are supported:
 
-This project uses the following libraries:
+- C#
+- Python
+- C++
+
+Each implementation can be found in the respective directory under `src/`.
+
+## C# Implementation
+
+The C# implementation can be found in the `src/csharp` directory. This implementation uses the MathNet.Numerics library.
+
+### Dependencies
+
+The C# implementation uses the following libraries:
 
 - [MathNet.Numerics](https://github.com/mathnet/mathnet-numerics) (MIT License)
 
-## Usage
-
-The primary class in this project is KalmanFilter. You can create an instance of the class and then use it as follows:
+### Usage
 
 ```csharp
 using MathNet.Numerics.LinearAlgebra;
@@ -44,5 +53,103 @@ kf.Update(z);
 var currentState = kf.GetCurrentState();
 ```
 
+Please replace the ... with appropriate data.  
+
+## Python Implementation
+
+The Python implementation can be found in the `src/python` directory.
+
+### Dependencies
+
+The Python implementation uses the following libraries:
+
+- [numpy](https://numpy.org/) (BSD License)
+- [scipy](https://www.scipy.org/) (BSD License)
+
+### Usage
+
+```python
+import numpy as np
+from kalman_filter import KalmanFilter
+
+# Initialize the Kalman Filter
+F = np.array([[...]])  # State transition matrix
+H = np.array([[...]])  # Observation matrix
+B = np.array([[...]])  # Control matrix
+x = np.array([[...]])  # Initial state estimate
+P = np.array([[...]])  # Initial error covariance estimate
+Q = np.array([[...]])  # Estimated error in process
+R = np.array([[...]])  # Estimated error in measurement
+
+kf = KalmanFilter(F, H, B, x, P, Q, R)
+
+# Update the state transition matrix
+dt = ...  # Time step
+kf.update_state_transition_matrix(dt)
+
+# Predict the next state
+u = np.array([[...]])  # Control input
+kf.predict(u)
+
+# Update the state with the observation
+z = np.array([[...]])  # Observation
+kf.update(z)
+
+# Get the current state estimate
+x = kf.get_current_state()
+```
+
 Please replace the ... with appropriate data.
-Remember to add using MathNet.Numerics.LinearAlgebra; and using MathNet.Numerics.Distributions; at the beginning of your file.
+
+## C++ Implementation
+
+The C++ implementation can be found in the `src/cpp` directory.
+### Dependencies
+
+The C++ implementation uses the following libraries:
+
+- [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) (MPL2 License)
+- [Boost](https://www.boost.org/) (Boost Software License)
+
+### Usage
+
+```cpp
+#include "KalmanFilter.h"
+#include <Eigen/Dense>
+#include <boost/math/distributions/chi_squared.hpp>
+
+// Initialize model parameters
+Eigen::MatrixXd F = ...; // State transition matrix
+Eigen::MatrixXd B = ...; // Control matrix
+Eigen::MatrixXd H = ...; // Observation matrix
+Eigen::MatrixXd x = ...; // Initial state estimate
+Eigen::MatrixXd P = ...; // Initial error covariance estimate
+Eigen::MatrixXd Q = ...; // Estimated error in process
+Eigen::MatrixXd R = ...; // Estimated error in measurements
+
+// Create an instance of the KalmanFilter class
+KalmanFilter kf(F, B, H, x, P, Q, R);
+
+// Time step
+double dt = ...;
+
+// Update the state transition matrix
+kf.update_state_transition_matrix(dt);
+
+// Control vector
+Eigen::MatrixXd u = ...;
+
+// Perform the prediction step
+kf.predict(u);
+
+// Measurement vector
+Eigen::MatrixXd z = ...;
+
+// Perform the update step
+kf.update(z);
+
+// Get the current state estimate
+Eigen::MatrixXd currentState = kf.get_current_state();
+```
+
+Please replace the ... with appropriate data.

--- a/src/cpp/KalmanFilter.cpp
+++ b/src/cpp/KalmanFilter.cpp
@@ -1,0 +1,49 @@
+#include "KalmanFilter.h"
+#include <Eigen/Dense>
+#include <boost/math/distributions/chi_squared.hpp>
+
+KalmanFilter::KalmanFilter(Eigen::MatrixXd F, Eigen::MatrixXd B, Eigen::MatrixXd H, 
+                           Eigen::MatrixXd x, Eigen::MatrixXd P, Eigen::MatrixXd Q, 
+                           Eigen::MatrixXd R)
+    : F(F), B(B), H(H), x(x), P(P), Q(Q), R(R) {}
+
+void KalmanFilter::update_state_transition_matrix(double dt) {
+    int n = F.rows();
+    for (int i = 0; i < n / 2; i++) {
+        F(i, i + n / 2) = dt;
+    }
+}
+
+// Predict step: update the state and error covariance
+void KalmanFilter::predict(Eigen::MatrixXd u) {
+    x = F * x + B * u;
+    P = F * P * F.transpose() + Q;
+}
+
+// Update step: update the state and error covariance based on the observation
+void KalmanFilter::update(Eigen::MatrixXd z, double outlier_threshold) {
+    Eigen::MatrixXd y = z - H * x;
+    Eigen::MatrixXd S = H * P * H.transpose() + R;
+
+    // Calculate the Mahalanobis distance
+    double D = sqrt((y.transpose() * S.inverse() * y)(0, 0));
+
+    // Calculate the threshold based on the chi-squared distribution
+    boost::math::chi_squared chi_squared(y.size());
+    double threshold = boost::math::quantile(chi_squared, 1 - outlier_threshold);
+
+    // If the Mahalanobis distance is greater than the threshold,
+    // consider the observation as an outlier and skip the update step
+    if (D > threshold) {
+        return;
+    }
+
+    Eigen::MatrixXd K = P * H.transpose() * S.inverse();
+    x = x + K * y;
+    P = (Eigen::MatrixXd::Identity(P.rows(), P.cols()) - K * H) * P;
+}
+
+// Get the current state estimate
+Eigen::MatrixXd KalmanFilter::get_current_state() {
+    return x;
+}

--- a/src/cpp/KalmanFilter.h
+++ b/src/cpp/KalmanFilter.h
@@ -1,0 +1,20 @@
+#ifndef KALMANFILTER_H
+#define KALMANFILTER_H
+
+#include <Eigen/Dense>
+
+class KalmanFilter {
+public:
+    Eigen::MatrixXd F, B, H, x, P, Q, R;
+
+    KalmanFilter(Eigen::MatrixXd F, Eigen::MatrixXd B, Eigen::MatrixXd H, 
+                 Eigen::MatrixXd x, Eigen::MatrixXd P, Eigen::MatrixXd Q, 
+                 Eigen::MatrixXd R);
+
+    void update_state_transition_matrix(double dt);
+    void predict(Eigen::MatrixXd u);
+    void update(Eigen::MatrixXd z, double outlier_threshold = 0.01);
+    Eigen::MatrixXd get_current_state();
+};
+
+#endif

--- a/src/csharp/Classes/KalmanSharp.cs
+++ b/src/csharp/Classes/KalmanSharp.cs
@@ -12,7 +12,15 @@ public class KalmanFilter
     private Matrix<float> R; // Estimated error in measurement
 
     // Constructor: set initial values and matrices
-    public KalmanFilter(Matrix<float> F, Matrix<float> B, Matrix<float> H, Matrix<float> x0, Matrix<float> P0, Matrix<float> Q, Matrix<float> R)
+    public KalmanFilter(
+        Matrix<float> F,
+        Matrix<float> B,
+        Matrix<float> H,
+        Matrix<float> x0,
+        Matrix<float> P0,
+        Matrix<float> Q,
+        Matrix<float> R
+    )
     {
         this.F = F;
         this.B = B; 
@@ -21,6 +29,16 @@ public class KalmanFilter
         this.P = P0;
         this.Q = Q;
         this.R = R;
+    }
+
+    // Update the state transition matrix based on the time step dt.
+    public void UpdateStateTransitionMatrix(float dt)
+    {
+        int n = F.RowCount;
+        for (int i = 0; i < n / 2; i++)
+        {
+            F[i, i + n / 2] = dt;
+        }
     }
 
     // Predict step: update the state and error covariance
@@ -42,7 +60,8 @@ public class KalmanFilter
         // Calculate the threshold based on the chi-squared distribution
         float threshold = (float)ChiSquared.InvCDF(y.RowCount, 1 - outlierThreshold);
 
-        // If the Mahalanobis distance is greater than the threshold, consider the observation as an outlier and skip the update step
+        // If the Mahalanobis distance is greater than the threshold
+        // consider the observation as an outlier and skip the update step
         if (D > threshold)
         {
             return;

--- a/src/python/kalman_filter.py
+++ b/src/python/kalman_filter.py
@@ -1,0 +1,50 @@
+
+import numpy as np
+from scipy.stats import chi2
+from numpy.linalg import inv
+
+
+class KalmanFilter:
+    def __init__(self, F, B, H, x, P, Q, R):
+        self.F = F
+        self.B = B
+        self.H = H
+        self.x = x
+        self.P = P
+        self.Q = Q
+        self.R = R
+
+    # Update the state transition matrix based on the time step dt
+    def update_state_transition_matrix(self, dt):
+        n = self.F.shape[0]
+        for i in range(n // 2):
+            self.F[i, i + n // 2] = dt
+
+    # Predict step: update the state and error covariance
+    def predict(self, u):
+        self.x = self.F @ self.x + self.B @ u
+        self.P = self.F @ self.P @ self.F.T + self.Q
+
+    # Update step: update the state and error covariance based on the observation
+    def update(self, z, outlier_threshold=0.01):
+        y = z - self.H @ self.x
+        S = self.H @ self.P @ self.H.T + self.R
+
+        # Calculate the Mahalanobis distance
+        D = np.sqrt((y.T @ inv(S) @ y)[0, 0])
+
+        # Calculate the threshold based on the chi-squared distribution
+        threshold = chi2.ppf(1 - outlier_threshold, df=y.shape[0])
+
+        # If the Mahalanobis distance is greater than the threshold,
+        # consider the observation as an outlier and skip the update step
+        if D > threshold:
+            return
+
+        K = self.P @ self.H.T @ inv(S)
+        self.x = self.x + K @ y
+        self.P = (np.eye(self.P.shape[0]) - K @ self.H) @ self.P
+
+    # Get the current state estimate
+    def get_current_state(self):
+        return self.x


### PR DESCRIPTION
## Add Python and C++ implementations of the Kalman filter

This pull request adds Python and C++ implementations of the Kalman filter to the existing repository. This addition aims to broaden the utility of the repository for developers who use different programming languages.

Here is a summary of the changes:

1.  Fix a C#  implementation.
2. Added a Python implementation of the Kalman filter in the `src/python` directory.
3. Added a C++ implementation of the Kalman filter in the `src/cpp` directory.
4. Updated the README file to include usage instructions for the Python and C++ implementations.

The Python implementation and C++ implementation  follow the same logic and structure as the  C# implementation, and they include the addition of an `update_state_transition_matrix` method for handling systems with time-dependent state transition matrices.